### PR TITLE
Fix yellowbox warnings

### DIFF
--- a/src/SegmentControl/Segment.js
+++ b/src/SegmentControl/Segment.js
@@ -19,7 +19,7 @@ Segment.defaultProps = {
 
 Segment.propTypes = {
   title: PropTypes.string.isRequired,
-  textStyle: Text.propTypes.style,
+  textStyle: Text.propTypes.style.isRequired,
   onPress: PropTypes.func.isRequired,
   style: ViewPropTypes.style
 }

--- a/src/SegmentControl/Segment.js
+++ b/src/SegmentControl/Segment.js
@@ -19,7 +19,7 @@ Segment.defaultProps = {
 
 Segment.propTypes = {
   title: PropTypes.string.isRequired,
-  textStyle: ViewPropTypes.style.isRequired,
+  textStyle: Text.propTypes.style,
   onPress: PropTypes.func.isRequired,
   style: ViewPropTypes.style
 }

--- a/src/SegmentControl/index.js
+++ b/src/SegmentControl/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { View, Animated, ViewPropTypes, Easing } from 'react-native'
+import { View, Animated, ViewPropTypes, Easing, Text } from 'react-native'
 
 import styles from './styles'
 import Segment from './Segment'
@@ -81,6 +81,7 @@ class SegmentControl extends React.Component {
         >
           {this.props.values.map((segment, index) => (
             <Segment
+              key={index}
               style={{ height: segmentHeight }}
               title={segment}
               textStyle={index !== this.state.selectedIndex ? unSelectedTextStyle : {...styles.activeText, ...selectedTextStyle}}
@@ -160,12 +161,12 @@ SegmentControl.propTypes = {
   /**
    * Selected Segment text style.
    */
-  selectedTextStyle: ViewPropTypes.style,
+  selectedTextStyle: Text.propTypes.style,
 
   /**
    * Unselected Segment text style.
    */
-  unSelectedTextStyle: ViewPropTypes.style,
+  unSelectedTextStyle: Text.propTypes.style,
 }
 
 export default SegmentControl


### PR DESCRIPTION
Fixes #2 

- Fixed proptype warning that occurs when trying to use the 'color' style since ViewPropTypes prop does support color style.
- Above was changed for the textStyle, selectedTextStyle and unselectedTextStyle props.
- Changed no unique key warning that occured by adding a key prop to Segment