### PR TITLE
Added componentDidUpdate() to updated selectedIndex

### DIFF
--- a/src/SegmentControl/index.js
+++ b/src/SegmentControl/index.js
@@ -20,6 +20,27 @@ class SegmentControl extends React.Component {
       positionAnimationValue: new Animated.Value(0)
     }
   }
+  
+  
+  componentDidUpdate(prevProps) {
+    if (prevProps.selectedIndex !== this.props.selectedIndex) {
+      const animate = () => {
+        Animated.timing(this.state.positionAnimationValue, {
+          toValue: this.state.activeSegmentPosition.x,
+          duration: 150,
+          easing: Easing.ease
+        }).start()
+      }
+
+      this.setState(
+          prevState => ({
+            selectedIndex: this.props.selectedIndex,
+            activeSegmentPosition: { x: prevState.segmentDimension.width * this.props.selectedIndex  + this.props.offsetHeight, y: prevState.activeSegmentPosition.y }
+          }),
+          animate
+      )
+    }
+  }
 
   /**
    * On segment change event.


### PR DESCRIPTION
When `selectedIndex prop` is changed the component doesn't update the `selectedIndex state`, the component then doesn't animate the segment to the updated position. To fix this I added `componentDidUpdate` which checks if the props changed, if they did I update the state and animate the segment to the new position.